### PR TITLE
Fix ARDUINO_INSTALL_PATH error

### DIFF
--- a/Arduino-toolchain.cmake
+++ b/Arduino-toolchain.cmake
@@ -62,6 +62,9 @@ include(Arduino/System/BoardBuildTargets)
 # board's toolchain info is configured to a generated file that gets
 # included in every other inclusion of this toolchain.
 if (NOT _BOARD_INDEXING_COMPLETED)
+	get_property(_in_try_compile GLOBAL PROPERTY IN_TRY_COMPILE)
+	# IN_TRY_COMPILE check seems to be not enough. Check for parent
+	# script works, but may be undocumented!
 	get_filename_component(parent_script "${_ARDUINO_TOOLCHAIN_PARENT}"
 		NAME_WE)
 	if (parent_script STREQUAL "CMakeSystem")

--- a/Arduino/System/PackagePathIndex.cmake
+++ b/Arduino/System/PackagePathIndex.cmake
@@ -105,5 +105,3 @@ function(InitializeArduinoPackagePathList)
 	# message("ARDUINO_SKETCHBOOK_PATH:${ARDUINO_SKETCHBOOK_PATH}")
 
 endfunction()
-
-InitializeArduinoPackagePathList()

--- a/Arduino/System/PlatformIndex.cmake
+++ b/Arduino/System/PlatformIndex.cmake
@@ -32,6 +32,8 @@ function(IndexArduinoPlatforms namespace)
 	set(json_count 0)
 	set("${namespace}/list")
 
+	InitializeArduinoPackagePathList()
+
 	if (EXISTS "${ARDUINO_INSTALL_PATH}/hardware/package_index_bundled.json")
 		# message(STATUS "Parsing package ${ARDUINO_INSTALL_PATH}/hardware/package_index_bundled.json")
 		file(READ "${ARDUINO_INSTALL_PATH}/hardware/package_index_bundled.json" json_content)


### PR DESCRIPTION
Fixing the error that is caused when manually providing the
Android IDE installation path to the toolchain using the option
-D ARDUINO_INSTALL_PATH=<path/to/ArduinoInstallation>