### PR TITLE
CMake policy version setting

### DIFF
--- a/Arduino-toolchain.cmake
+++ b/Arduino-toolchain.cmake
@@ -4,8 +4,7 @@
 # A toolchain for the Arduino compatile boards.
 # Please refer to README.md for the usage.
 
-#*****************************************************************************
-# If not using the required CMake version, exit with error
+# If the version of CMake used is below 3.7.0, exit with error.
 #
 # Intended to support CMake version 3.0.0, but there are limitations which
 # requires a minimum CMake version of 3.7.0. However, wherever possible, the
@@ -33,6 +32,9 @@ endif()
 
 # Save the policy state. We will restore it at the end.
 cmake_policy(PUSH)
+
+# Set policy to above 3.0.0
+cmake_policy(VERSION 3.0.0)
 
 # Interpret if() arguments without quotes as variables/keywords
 if (NOT CMAKE_VERSION VERSION_LESS 3.1)

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -11,7 +11,7 @@ If there are errors related to CMake version, update CMake or download/build a l
 
 If there are errors (related to not finding Arduino IDE installation), please install the Arduino IDE and follow the instructions to guide the toolchain with the installation path.
 
-As we have not yet chosen an Arduino board yet, the above *cmake* command exists with error, prompting to select a board from the generated BoardOptions.txt in *Examples_build* folder. Edit the file to choose the board and then reinvoke the command.
+As we have not yet chosen an Arduino board yet, the above *cmake* command exits with error, prompting to select a board from the generated BoardOptions.txt in *Examples_build* folder. Edit the file to choose the board and then reinvoke the command.
 
 ```sh
 cmake -D CMAKE_TOOLCHAIN_FILE=../Arduino-toolchain.cmake ../Examples


### PR DESCRIPTION
Sets CMake policy version within the toolchain to 3.0.0
explicitly to prevent errors due to some script asumptions,
like working of while(TRUE).