### PR TITLE
Broken build

### DIFF
--- a/Arduino/System/BoardBuildTargets.cmake
+++ b/Arduino/System/BoardBuildTargets.cmake
@@ -7,6 +7,7 @@ endif()
 set(_BOARD_BUILD_TARGETS_INCLUDED TRUE)
 
 include(CMakeParseArguments)
+INCLUDE(Arduino/Utilities/CommonUtils)
 INCLUDE(Arduino/Utilities/SourceLocator)
 include(Arduino/Utilities/SourceDependency)
 include(Arduino/System/BoardToolchain)
@@ -733,6 +734,10 @@ function(_add_internal_arduino_core target)
 	endif()
 	# find_header_files("${ARDUINO_BOARD_BUILD_CORE_PATH}" core_headers)
 	# find_header_files("${ARDUINO_BOARD_BUILD_VARIANT_PATH}" variant_headers)
+
+	# On some platforms, files ending with small case .s not taken and cause issues
+	# filter this out
+	list_filter_exclude_regex(core_sources ".s$")
 
 	# get_headers_parent_directories("${core_headers};${variant_headers}" include_dirs)
 

--- a/Arduino/Utilities/CommonUtils.cmake
+++ b/Arduino/Utilities/CommonUtils.cmake
@@ -26,6 +26,27 @@ function(list_filter_include_regex _list_var _regex)
 
 endfunction()
 
+# List filter is not available in older versions of cmake
+# Providing equivalent versions for the same
+function(list_filter_exclude_regex _list_var _regex)
+
+	if (CMAKE_VERSION VERSION_LESS 3.6.3)
+		set(_result)
+		foreach(_elem IN LISTS "${_list_var}")
+			string(REGEX MATCH "${_regex}" _match "${_elem}")
+			if (NOT _match)
+				list(APPEND _result "${_elem}")
+			endif()
+		endforeach()
+		set("${_list_var}" "${_result}" PARENT_SCOPE)
+	else()
+		list(FILTER "${_list_var}" EXCLUDE REGEX  "${_regex}")
+		set("${_list_var}" "${${_list_var}}" PARENT_SCOPE)
+	endif()
+
+endfunction()
+
+
 # List TRANSFORM is not available in older versions of cmake
 # Providing equivalent versions for the same
 function(list_transform_replace _list_var _regex _replace)

--- a/Arduino/Utilities/SourceLocator.cmake
+++ b/Arduino/Utilities/SourceLocator.cmake
@@ -14,7 +14,7 @@ set(ARDUINO_CMAKE_C_FILES_PATTERN *.c CACHE STRING
 		"C Source Files Pattern")
 set(ARDUINO_CMAKE_CXX_FILES_PATTERN *.cc *.cpp *.cxx CACHE STRING
 		"CXX Source Files Pattern")
-set(ARDUINO_CMAKE_ASM_FILES_PATTERN *.[S] CACHE STRING
+set(ARDUINO_CMAKE_ASM_FILES_PATTERN *.[sS] CACHE STRING
 		"ASM Source Files Pattern")
 set(ARDUINO_CMAKE_HEADER_FILES_PATTERN *.h *.hh *.hpp *.hxx CACHE STRING
 		"Header Files Pattern")


### PR DESCRIPTION
Disabling small case .s files for the core in the last commit
had side effects in breaking some builds. Fixing the problem
with alternative changes for excluding .s