### PR TITLE
(#35) Set extra.time.local property in SetupBoardToolchain function

### DIFF
--- a/Arduino/System/BoardToolchain.cmake
+++ b/Arduino/System/BoardToolchain.cmake
@@ -182,7 +182,7 @@ function (SetupBoardToolchain boards_namespace board_id generate_dir)
 
 	# Set some extra properties
 	if (${CMAKE_HOST_UNIX})
-		execute_process(COMMAND "date" "+'%s'" OUTPUT_VARIABLE EPOCH)
+		execute_process(COMMAND "date" "+%s" OUTPUT_VARIABLE EPOCH)
 		properties_set_value("ard_global" "extra.time.local" "${EPOCH}")
 	endif()
 

--- a/Arduino/System/BoardToolchain.cmake
+++ b/Arduino/System/BoardToolchain.cmake
@@ -180,6 +180,12 @@ function (SetupBoardToolchain boards_namespace board_id generate_dir)
 	endif()
 	properties_set_value("ard_global" "runtime.os" "${ARDUINO_BOARD_HOST_NAME}")
 
+	# Set some extra properties
+	if (${CMAKE_HOST_UNIX})
+		execute_process(COMMAND "date" "+'%s'" OUTPUT_VARIABLE EPOCH)
+		properties_set_value("ard_global" "extra.time.local" "${EPOCH}")
+	endif()
+
 	# Packager of the selected board
 	_board_get_platform_property("/pkg_id" pkg_id)
 	_board_get_platform_property("/json_idx" json_idx)


### PR DESCRIPTION
Teensy board.txt file is using extra.time.local to define
__rtc_localtime symbol at link time.
For Linux, using `date +'%s'` gives epoch time, use this comand to
compute time using subprocess_command.

Signed-off-by: leo sartre <leo.sartre@e.email>