### PR TITLE
Add basic support for arduino-cli detection

### DIFF
--- a/Arduino/System/PackagePathIndex.cmake
+++ b/Arduino/System/PackagePathIndex.cmake
@@ -86,11 +86,14 @@ function(InitializeArduinoPackagePathList)
 		file(GLOB package_search_paths "$ENV{LOCALAPPDATA}/Arduino15")
 		set(package_path_suffixes "")
 
-		set(_reg_software "HKEY_LOCAL_MACHINE\\SOFTWARE")
+		set(_reg_software "HKEY_CURRENT_USER\\SOFTWARE")
 		set(_reg_win "${_reg_software}\\Microsoft\\Windows\\CurrentVersion")
 		set(_reg_explorer "${_reg_win}\\Explorer")
+		get_filename_component(_reg_documents
+			"[${_reg_explorer}\\User Shell Folders;Personal]" ABSOLUTE)
+
 		file(GLOB sketchbook_search_paths "$ENV{LOCALAPPDATA}/Arduino15"
-			"[${_reg_explorer}\\User Shell Folders;Personal]/ArduinoData")
+			"${_reg_documents}/ArduinoData")
 		set(sketchbook_path_suffixes "")
 	else()
 

--- a/Arduino/System/PackagePathIndex.cmake
+++ b/Arduino/System/PackagePathIndex.cmake
@@ -162,6 +162,18 @@ function(InitializeArduinoPackagePathList)
 	endif()
 	# message("ARDUINO_SKETCHBOOK_PATH:${ARDUINO_SKETCHBOOK_PATH}")
 
+	# support arduino-cli package downloads on Windows. Sketchbook path will be
+	# not found if IDE is not installed, so use the Documents/Arduino as
+	# additional library lookup paths. This is the expected location when running
+	# arduino-cli lib install <library>.
+	if (NOT ARDUINO_SKETCHBOOK_PATH AND _reg_documents)
+		file(GLOB _reg_doc_lib "${_reg_documents}/Arduino")
+		if (_reg_doc_lib)
+			set(ARDUINO_SKETCHBOOK_PATH "${_reg_doc_lib}"
+				CACHE PATH "Path to Arduino Libraries")
+		endif()
+	endif()
+
 	# Arduino local package management path
 	if (NOT ARDUINO_PACKAGE_MANAGER_PATH)
 		set(ARDUINO_PACKAGE_MANAGER_PATH


### PR DESCRIPTION
This adds the most basic of support for the environment created from
downloading the Arduino SDK via the official [arduino-cli project][1].

It fixes two issues encountered with detection:

1. If `set(ARDUINO_INSTALL_PATH "$env{LOCALAPPDATA}/Arduino15` is used,
   it will work, however the make system will loudly complain that it is
   unable to read `lib/version.txt`, however generation will succeed.
2. By default, the cli installation is not detected, so this adds the
   install path hint of the `$env{LOCALAPPDATA}/Arduino15` path and adds
   basic detection of `arduino-cli.yaml` which is created from the cli
   setup process.

The Linux update has been validated using Debian Buser running under
WSL1 and all tools work as far as I can tell, including detection,
build, sizing, and upload.

I do not have a Mac available to test, but I am basing the assumption of
`$ENV{HOME}/Library/Arduino15` as the install point since that's in the
package path as well.

Using the tool, running a command like `arduino-cli core install arduino:samd`
will download the tooling, the core, and set up the environment.

Originally I was detecting `arduino-cli.yaml` as the marker file but
under a brand new installation on Linux that file did not exist, but
`inventory.yaml` did.

I was unable to detect any version information of a matching SDK or
arduino-cli version, so the assumption of the file existing was enough
to trigger the new flow.

[1]: https://github.com/arduino/arduino-cli

----

Fix registry bug when globbing for sketchbook

The existing code fails on Windows installations as it was checking
`HKEY_LOCAL_MACHINE` instead of the user defined/customized
`HKEY_CURRENT_USER` as the `Personal` registry value only exists in the
user registry.

Additionally, the `file` command does not seem to resolve the registry
directive, so an additional call to `get_filename_component` was added
to resolve the directory path.

----

Add support for cli-installed libs without IDE

If a library is installed from the Arduino CLI via `arduino-cli lib
install <lib>` on Windows, the default location for the installed
library is under `Documents/Arduino/Libraries/<lib>`. When the IDE is
not installed, a preferences file pointing to this location is not
created and is not recognized by the build system.

This attempts to resolve the issue by detecting a missing sketchbook
location and the existance of the `_reg_documents` variable (resolved
when setting up package paths) by resolving the location and setting the
appropriate `ARDUINO_SKETCHBOOK_PATH` variable, allowing library
searches to find libraries installed by the CLI.

