### PR TITLE
Resolve property as long as possible

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -218,6 +218,7 @@ function(SetupBoardTests)
 		set_tests_properties("${distinct_id}" PROPERTIES
 			FIXTURES_REQUIRED "PlTestResults"
 			SKIP_RETURN_CODE 100
+			TIMEOUT 3600
 		)
 
 		if ("${shell_cmd}" STREQUAL "" AND
@@ -354,6 +355,7 @@ function(SetupPlatformTests pl_url ref_url_list return_pl_tests)
 		set_tests_properties("${test_id}" PROPERTIES
 			FIXTURES_REQUIRED "TestResults"
 			SKIP_RETURN_CODE 100
+			TIMEOUT 3600
 		)
 		if ("${shell_cmd}" STREQUAL "" AND
 			NOT CMAKE_VERSION VERSION_LESS "3.16.0")


### PR DESCRIPTION
This change repeats resolve property process so that
consecutive substitutions are possible. That may be
required if the property requires multiple
iterations to be resolved. For instance the
following property requires 2 iterations:
compiler.path={runtime.tools.{build.tarch}-{build.target}-elf-gcc.path}/bin
After the first iterations the form requires one
more substitution
compiler.path={runtime.tools.xtensa-esp32-elf-gcc.path}/bin